### PR TITLE
Different host for some APIs

### DIFF
--- a/google-api-async.js
+++ b/google-api-async.js
@@ -8,9 +8,9 @@ GoogleApi = {
   _callAndRefresh: function(method, path, options, callback) {
     var self = this;
     options = options || {};
-        
-    self._call(method, path, options,       
-      // need to bind the env here so we can do mongo writes in the callback 
+
+    self._call(method, path, options,
+      // need to bind the env here so we can do mongo writes in the callback
       // (when refreshing), if we call this on the server
       Meteor.bindEnvironment(function(error, result) {
         if (error && error.response && error.response.statusCode == 401) {
@@ -19,12 +19,12 @@ GoogleApi = {
           return self._refresh(options.user, function(error) {
             if (error)
               return callback(error);
-            
+
             // if we have the user, we'll need to re-fetch them, as their
             // access token will have changed.
             if (options.user)
               options.user = Meteor.users.findOne(options.user._id);
-            
+
             self._call(method, path, options, callback);
           });
         } else {
@@ -32,20 +32,21 @@ GoogleApi = {
         }
     }, 'Google Api callAndRefresh'));
   },
-  
+
   // call a GAPI Meteor.http function if the accessToken is good
   _call: function(method, path, options, callback) {
     Log('GoogleApi._call, path:' + path);
-    
+
     options = options || {};
     var user = options.user || Meteor.user();
-    
-    if (user && user.services && user.services.google && 
+
+    if (user && user.services && user.services.google &&
         user.services.google.accessToken) {
       options.headers = options.headers || {};
       options.headers.Authorization = 'Bearer ' + user.services.google.accessToken;
-    
-      HTTP.call(method, this._host + '/' + path, options, function(error, result) {
+
+      var host = options.host || this._host;
+      HTTP.call(method, host + '/' + path, options, function(error, result) {
         callback(error, result && result.data);
       });
     } else {

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'percolate:google-api',
   summary: "A Meteor library to interact with Google's API",
-  version: '1.0.1',
+  version: '1.0.2',
   git: 'https://github.com/percolatestudio/meteor-google-api'
 });
 
@@ -12,10 +12,10 @@ Package.on_use(function (api, where) {
   } else {
     api.use(['http', 'livedata', 'google', 'q', 'accounts-base', 'underscore']);
   }
-  
+
   api.add_files(['utils.js', 'google-api-async.js'], ['client', 'server']);
   api.add_files(['google-api-methods.js'], ['server']);
-  
+
   api.export('GoogleApi', ['client', 'server']);
 });
 


### PR DESCRIPTION
Some APIs (like Contacts for instance - https://developers.google.com/google-apps/contacts/v3/reference#Feeds) use a different _host than googleapis.com. We should be able to set it through options.