### PR TITLE
Allow result.content in addition to result.data

### DIFF
--- a/google-api-async.js
+++ b/google-api-async.js
@@ -47,7 +47,7 @@ GoogleApi = {
       options.headers.Authorization = 'Bearer ' + user.services.google.accessToken;
     
       HTTP.call(method, this._host + '/' + path, options, function(error, result) {
-        callback(error, result && result.data);
+        callback(error, result && (result.data || result.content));
       });
     } else {
       callback(new Meteor.Error(403, "Auth token not found." +


### PR DESCRIPTION
Some google apis return content as "result.content" rather than result.data (such as the Google Contacts api).

This adds the option of choosing result.content if result.data does not exist.