### PR TITLE
Allow for a different host

### DIFF
--- a/google-api-async.js
+++ b/google-api-async.js
@@ -47,6 +47,8 @@ GoogleApi = {
       options.headers = options.headers || {};
       options.headers.Authorization = 'Bearer ' + user.services.google.accessToken;
 
+      path = /^http(s)?:\/\//.test(path)?path:this._host + '/' + path;
+
       HTTP.call(method, this._host + '/' + path, options, function(error, result) {
         callback(error, result && result.data);
       });


### PR DESCRIPTION
Check if `path` begins with "http://" or "https://" and refrain from
preppeding the default host if it does.
Changed in order to be able to use the package with Google Spreadsheets
API (that uses a different host).
