### PR TITLE
meteor method permission fix

### DIFF
--- a/google-api-methods.js
+++ b/google-api-methods.js
@@ -3,6 +3,14 @@ Meteor.methods({
   exchangeRefreshToken: function(userId) {
     this.unblock();
     
+    if (this.connection) {  //when called from client
+      if (this.userId) {
+        userId = this.userId;
+      } else {
+        throw new Meteor.Error(403, "Must be signed in to use Google API.");
+      } 
+    }
+    
     var user;
     if (userId && Meteor.isServer) {
       user = Meteor.users.findOne({_id: userId});


### PR DESCRIPTION
Prevent the refreshAccessToken method from being run from the client when users have not logged in or from being run on other users.