### PR TITLE
Update to new Meteor Google Oauth package name

### DIFF
--- a/package.js
+++ b/package.js
@@ -8,9 +8,9 @@ Package.describe({
 Package.on_use(function (api, where) {
   if (api.versionsFrom) {
     api.versionsFrom('0.9.0');
-    api.use(['http', 'livedata', 'google', 'mrt:q@1.0.1', 'accounts-base', 'underscore']);
+    api.use(['http', 'livedata', 'google-oauth', 'mrt:q@1.0.1', 'accounts-base', 'underscore']);
   } else {
-    api.use(['http', 'livedata', 'google', 'q', 'accounts-base', 'underscore']);
+    api.use(['http', 'livedata', 'google-oauth', 'q', 'accounts-base', 'underscore']);
   }
 
   api.add_files(['utils.js', 'google-api-async.js'], ['client', 'server']);


### PR DESCRIPTION
Meteor recently updated their package naming from `google` to `google-oauth` which resulted in an error per [this issue](https://github.com/percolatestudio/meteor-google-api/issues/40). This update resolves that issue.